### PR TITLE
infoObjSize changed from []int to map[TypeID]int

### DIFF
--- a/asdu/identifier.go
+++ b/asdu/identifier.go
@@ -164,7 +164,7 @@ const (
 
 // infoObjSize maps the type identification (TypeID) to the serial octet size.
 // Type extensions must register here.
-var infoObjSize = [256]int{
+var infoObjSize = map[TypeID]int{
 	M_SP_NA_1: 1,
 	M_SP_TA_1: 4,
 	M_DP_NA_1: 1,
@@ -233,8 +233,8 @@ var infoObjSize = [256]int{
 
 // GetInfoObjSize get the serial octet size of the type identification (TypeID).
 func GetInfoObjSize(id TypeID) (int, error) {
-	size := infoObjSize[id]
-	if size == 0 {
+	size, exists := infoObjSize[id]
+	if !exists {
 		return 0, ErrTypeIdentifier
 	}
 	return size, nil


### PR DESCRIPTION
The GetInfoObjSize() function is controlling if typeID is exists by comparing the typeID value by zero. but ReadCmd (C_RD_NA_1: 0) type has a zero value in the infoObjSize array. so it conflicts that, is value really zero or not exists. So this PR is fixes this problem by changing  infoObjSize type from []int to map[TypeID]int. and checking typeID existence by looking second parameter of indexing. map implementation completely fitting with array implementation.  